### PR TITLE
Implement basic sun + dark sky compensation into main branch

### DIFF
--- a/mcmt-tracking/mcmt-tracking/src/mcmt_detect/include/mcmt_detect/mcmt_multi_detect_node.hpp
+++ b/mcmt-tracking/mcmt-tracking/src/mcmt_detect/include/mcmt_detect/mcmt_multi_detect_node.hpp
@@ -97,6 +97,7 @@ class McmtMultiDetectNode : public rclcpp::Node {
 		cv::Mat remove_ground(std::shared_ptr<mcmt::Camera> & camera);
 		cv::Mat apply_bg_subtractions(std::shared_ptr<mcmt::Camera> & camera);
 		void apply_sun_compensation(std::shared_ptr<mcmt::Camera> & camera);
+		cv::Mat scale_hsv_pixels(cv::Mat sky);
 		float calc_sun_contrast_gain(cv::Mat sky);
 		void predict_new_locations_of_tracks(std::shared_ptr<mcmt::Camera> & camera);
 		void detection_to_track_assignment_KF(std::shared_ptr<mcmt::Camera> & camera);

--- a/mcmt-tracking/mcmt-tracking/src/mcmt_detect/include/mcmt_detect/mcmt_multi_detect_node.hpp
+++ b/mcmt-tracking/mcmt-tracking/src/mcmt_detect/include/mcmt_detect/mcmt_multi_detect_node.hpp
@@ -98,7 +98,6 @@ class McmtMultiDetectNode : public rclcpp::Node {
 		cv::Mat apply_bg_subtractions(std::shared_ptr<mcmt::Camera> & camera);
 		void apply_sun_compensation(std::shared_ptr<mcmt::Camera> & camera);
 		cv::Mat scale_hsv_pixels(cv::Mat sky);
-		float calc_sun_contrast_gain(cv::Mat sky);
 		void predict_new_locations_of_tracks(std::shared_ptr<mcmt::Camera> & camera);
 		void detection_to_track_assignment_KF(std::shared_ptr<mcmt::Camera> & camera);
 		void detection_to_track_assignment_DCF(std::shared_ptr<mcmt::Camera> & camera);

--- a/mcmt-tracking/mcmt-tracking/src/mcmt_detect/include/mcmt_detect/mcmt_single_detect_node.hpp
+++ b/mcmt-tracking/mcmt-tracking/src/mcmt_detect/include/mcmt_detect/mcmt_single_detect_node.hpp
@@ -122,7 +122,6 @@ class McmtSingleDetectNode : public rclcpp::Node {
 		cv::Mat apply_bg_subtractions();
 		void apply_sun_compensation();
 		cv::Mat scale_hsv_pixels(cv::Mat sky);
-		float calc_sun_contrast_gain(cv::Mat sky);
 		void predict_new_locations_of_tracks();
 		void detection_to_track_assignment_KF();
 		void detection_to_track_assignment_DCF();

--- a/mcmt-tracking/mcmt-tracking/src/mcmt_detect/include/mcmt_detect/mcmt_single_detect_node.hpp
+++ b/mcmt-tracking/mcmt-tracking/src/mcmt_detect/include/mcmt_detect/mcmt_single_detect_node.hpp
@@ -121,6 +121,7 @@ class McmtSingleDetectNode : public rclcpp::Node {
 		cv::Mat remove_ground();
 		cv::Mat apply_bg_subtractions();
 		void apply_sun_compensation();
+		cv::Mat scale_hsv_pixels(cv::Mat sky, int avg_brightness);
 		float calc_sun_contrast_gain(cv::Mat sky);
 		void predict_new_locations_of_tracks();
 		void detection_to_track_assignment_KF();
@@ -135,7 +136,7 @@ class McmtSingleDetectNode : public rclcpp::Node {
 		// declare utility functions
 		double euclideanDist(cv::Point2f & p, cv::Point2f & q);
 		std::vector<int> apply_hungarian_algo(std::vector<std::vector<double>> & cost_matrix);
-		int average_brightness(cv::ColorConversionCodes colortype, int channel);
+		int average_brightness(cv::ColorConversionCodes colortype, int channel, cv::Mat mask);
     std::string mat_type2encoding(int mat_type);
 		int encoding2mat_type(const std::string & encoding);
 };

--- a/mcmt-tracking/mcmt-tracking/src/mcmt_detect/include/mcmt_detect/mcmt_single_detect_node.hpp
+++ b/mcmt-tracking/mcmt-tracking/src/mcmt_detect/include/mcmt_detect/mcmt_single_detect_node.hpp
@@ -121,7 +121,7 @@ class McmtSingleDetectNode : public rclcpp::Node {
 		cv::Mat remove_ground();
 		cv::Mat apply_bg_subtractions();
 		void apply_sun_compensation();
-		cv::Mat scale_hsv_pixels(cv::Mat sky, int avg_brightness);
+		cv::Mat scale_hsv_pixels(cv::Mat sky);
 		float calc_sun_contrast_gain(cv::Mat sky);
 		void predict_new_locations_of_tracks();
 		void detection_to_track_assignment_KF();
@@ -136,7 +136,7 @@ class McmtSingleDetectNode : public rclcpp::Node {
 		// declare utility functions
 		double euclideanDist(cv::Point2f & p, cv::Point2f & q);
 		std::vector<int> apply_hungarian_algo(std::vector<std::vector<double>> & cost_matrix);
-		int average_brightness(cv::ColorConversionCodes colortype, int channel, cv::Mat mask);
+		int average_brightness(cv::ColorConversionCodes colortype, int channel);
     std::string mat_type2encoding(int mat_type);
 		int encoding2mat_type(const std::string & encoding);
 };

--- a/mcmt-tracking/mcmt-tracking/src/mcmt_detect/src/mcmt_multi_detect_node.cpp
+++ b/mcmt-tracking/mcmt-tracking/src/mcmt_detect/src/mcmt_multi_detect_node.cpp
@@ -262,40 +262,6 @@ cv::Mat McmtMultiDetectNode::scale_hsv_pixels(cv::Mat sky)
     return sky;
 }
 
-/**
- * This function calculates the value of contrast gain to be used in sun compensation
- * The gain is calculated based on the percentage of pixels in the sky that are white
- * The more white areas, the lower the gain should be to reduce probability of saturation
- */
-float McmtMultiDetectNode::calc_sun_contrast_gain(cv::Mat sky)
-{
-	cv::Mat gray_sky, white;
-
-	// Convert the sky_ frame to grayscale to easily determine which pixels are white
-	cv::cvtColor(sky, gray_sky, cv::COLOR_BGR2GRAY);
-	// cv::imshow("Gray sky", gray_sky);
-
-	// The total number of pixels in the sky (rest of the image is black)
-	float total_sky_pix = cv::countNonZero(gray_sky);
-
-	// Threshold the gray sky image to find the white pixels and put them in the "white" frame
-	// Empirical observation shows white pixels in sky typically have grayscale value > 175
-	auto lower = cv::Scalar(175);
-    auto upper = cv::Scalar(255);
-    cv::inRange(gray_sky, lower, upper, white);
-	// cv::imshow("White parts", white);
-
-	// Total number of white pixels in the sky
-	float white_sky_pix = cv::countNonZero(white);
-
-	// Percentage of sky pixels that are white, from 0 - 1
-	float white_sky_percent = white_sky_pix / total_sky_pix;
-
-	// Sun contrast gain (a) assumed to have negative linear relationship with white_sky_percent (N)
-	// At N = 0, a = max sun contrast gain; At N = 1, a = 1
-	return MAX_SUN_CONTRAST_GAIN - (MAX_SUN_CONTRAST_GAIN - 1) * white_sky_percent;
-}
-
 void McmtMultiDetectNode::detect_objects(std::shared_ptr<mcmt::Camera> & camera)
 {
 	camera->removebg_ = remove_ground(camera);

--- a/mcmt-tracking/mcmt-tracking/src/mcmt_detect/src/mcmt_single_detect_node.cpp
+++ b/mcmt-tracking/mcmt-tracking/src/mcmt_detect/src/mcmt_single_detect_node.cpp
@@ -291,40 +291,6 @@ cv::Mat McmtSingleDetectNode::scale_hsv_pixels(cv::Mat sky)
     return sky;
 }
 
-/**
- * This function calculates the value of contrast gain to be used in sun compensation
- * The gain is calculated based on the percentage of pixels in the sky that are white
- * The more white areas, the lower the gain should be to reduce probability of saturation
- */
-float McmtSingleDetectNode::calc_sun_contrast_gain(cv::Mat sky)
-{
-	cv::Mat gray_sky, white;
-
-	// Convert the sky_ frame to grayscale to easily determine which pixels are white
-	cv::cvtColor(sky, gray_sky, cv::COLOR_BGR2GRAY);
-	// cv::imshow("Gray sky", gray_sky);
-
-	// The total number of pixels in the sky (rest of the image is black)
-	float total_sky_pix = cv::countNonZero(gray_sky);
-
-	// Threshold the gray sky image to find the white pixels and put them in the "white" frame
-	// Empirical observation shows white pixels in sky typically have grayscale value > 175
-	auto lower = cv::Scalar(175);
-    auto upper = cv::Scalar(255);
-    cv::inRange(gray_sky, lower, upper, white);
-	// cv::imshow("White parts", white);
-
-	// Total number of white pixels in the sky
-	float white_sky_pix = cv::countNonZero(white);
-
-	// Percentage of sky pixels that are white, from 0 - 1
-	float white_sky_percent = white_sky_pix / total_sky_pix;
-
-	// Sun contrast gain (a) assumed to have negative linear relationship with white_sky_percent (N)
-	// At N = 0, a = max sun contrast gain; At N = 1, a = 1
-	return MAX_SUN_CONTRAST_GAIN - (MAX_SUN_CONTRAST_GAIN - 1) * white_sky_percent;
-}
-
 void McmtSingleDetectNode::detect_objects()
 {
 	removebg_ = remove_ground();

--- a/mcmt-tracking/mcmt-tracking/src/mcmt_detect/src/mcmt_single_detect_node.cpp
+++ b/mcmt-tracking/mcmt-tracking/src/mcmt_detect/src/mcmt_single_detect_node.cpp
@@ -231,11 +231,11 @@ void McmtSingleDetectNode::apply_sun_compensation()
 	cv::cvtColor(frame_, hsv, cv::COLOR_BGR2HSV);
 
 	// Threshold the HSV image to extract the sky and put it in sky frame
-	// The lower bound of V for clear, sunlit sky is given in SKY_THRES
+	// The threshold V value for sky is determined using Otsu thresholding
 	// The sky frame is kept in HSV for further operations
-	auto lower = cv::Scalar(0, 0, SKY_THRES);
-	auto upper = cv::Scalar(180, 255, 255);
-	cv::inRange(hsv, lower, upper, mask);
+	std::vector<cv::Mat> channels;
+	cv::split(hsv, channels);
+	cv::threshold(channels[2], mask, -1, 255, cv::THRESH_OTSU);
 	cv::bitwise_and(hsv, hsv, sky, mask);
 	// cv::imshow("sky", sky);
 

--- a/mcmt-tracking/mcmt-tracking/src/mcmt_detect/src/mcmt_single_detect_node.cpp
+++ b/mcmt-tracking/mcmt-tracking/src/mcmt_detect/src/mcmt_single_detect_node.cpp
@@ -216,7 +216,7 @@ cv::Mat McmtSingleDetectNode::apply_bg_subtractions()
 }
 
 /**
- * Apply sun compensation on frame and return the sun compensated frame.
+ * Apply sun compensation on frame
  * Sun compensation is needed when there is sunlight illuminating the target and making
  * it "blend" into sky. Increasing contrast of the entire frame is a solution, but it
  * generates false positives among treeline. Instead, sun compensation works by applying
@@ -224,61 +224,39 @@ cv::Mat McmtSingleDetectNode::apply_bg_subtractions()
  */
 void McmtSingleDetectNode::apply_sun_compensation()
 {
-	cv::Mat mask;
 
-	// For any dark regions (RGB channels all < 110), set it to black
-	auto lower = cv::Scalar(0, 0, 0);
-	auto upper = cv::Scalar(110, 110, 110);
-	auto transform = cv::Scalar(0, 0, 0);
-	cv::inRange(frame_, lower, upper, mask);
-	frame_.setTo(transform, mask);
-
-	// Decrease the saturation (using HSV frame)
-	cv::cvtColor(frame_, frame_, cv::COLOR_BGR2HSV);
-	transform = cv::Scalar(1, 0.3, 1);
-	cv::multiply(frame_, transform, frame_);
-	cv::cvtColor(frame_, frame_, cv::COLOR_HSV2BGR);
-
-	// cv::Mat hsv, sky, non_sky, mask, result;
+	cv::Mat hsv, sky, non_sky, mask;
 	
-	// // Get HSV version of the frame
-	// cv::cvtColor(frame_, hsv, cv::COLOR_BGR2HSV);
+	// Get HSV version of the frame
+	cv::cvtColor(frame_, hsv, cv::COLOR_BGR2HSV);
 
-	// // Threshold the HSV image to extract the sky and put it in sky frame
-	// // The lower bound of V for clear, sunlit sky is given in SKY_THRES
-	// // The sky frame is kept in HSV for further operations
-	// auto lower = cv::Scalar(0, 0, SKY_THRES);
-	// auto upper = cv::Scalar(180, 255, 255);
-	// cv::inRange(hsv, lower, upper, mask);
-	// cv::bitwise_and(hsv, hsv, sky, mask);
-	// // cv::imshow("sky", sky);
+	// Threshold the HSV image to extract the sky and put it in sky frame
+	// The lower bound of V for clear, sunlit sky is given in SKY_THRES
+	// The sky frame is kept in HSV for further operations
+	auto lower = cv::Scalar(0, 0, SKY_THRES);
+	auto upper = cv::Scalar(180, 255, 255);
+	cv::inRange(hsv, lower, upper, mask);
+	cv::bitwise_and(hsv, hsv, sky, mask);
+	// cv::imshow("sky", sky);
 
-	// // Extract the treeline and put it in non_sky frame
-	// // The mask for the treeline is the inversion of the sky mask
-	// // The treeline is converted back to RGB by using frame_ in the bitwise_and cmd
-	// cv::bitwise_not(mask, mask);
-	// cv::bitwise_and(frame_, frame_, non_sky, mask);
-	// // cv::imshow("non sky", non_sky);
+	// Extract the treeline and put it in non_sky frame
+	// The mask for the treeline is the inversion of the sky mask
+	// The treeline is converted back to RGB by using frame_ in the bitwise_and cmd
+	cv::bitwise_not(mask, mask);
+	cv::bitwise_and(frame_, frame_, non_sky, mask);
+	// cv::imshow("non sky", non_sky);
 
-	// // Decrease saturation value of the sky frame to avoid whiteout
-	// // After this operation, the sky can be converted back to RGB
-	// cv::multiply(sky, cv::Scalar(1, 0.3, 1), sky);
-	// cv::cvtColor(sky, sky, cv::COLOR_HSV2BGR);
+	// Decrease saturation value of the sky frame to avoid whiteout
+	// After this operation, the sky can be converted back to RGB
+	cv::multiply(sky, cv::Scalar(1, 0.3, 1), sky);
+	cv::cvtColor(sky, sky, cv::COLOR_HSV2BGR);
 
 	// sky.convertTo(sky, -1, MAX_SUN_CONTRAST_GAIN, SUN_BRIGHTNESS_GAIN);
 	// cv::erode(sky, sky, cv::getStructuringElement(0, cv::Size(5,5)));
 
-	// // Recombine the sky and treeline
-	// // cv::add(blue, non_blue, sky);
-	// cv::add(sky, non_sky, result);
-
-	// // Set dark components to black
-	// lower = cv::Scalar(0, 0, 0);
-	// upper = cv::Scalar(110, 110, 110);
-	// cv::inRange(result, lower, upper, mask);
-	// result.setTo(cv::Scalar(0, 0, 0), mask);
-
-	// return result;
+	// Recombine the sky and treeline
+	cv::add(sky, non_sky, frame_);
+	cv::imshow("After sun compensation", frame_);
 }
 
 /**


### PR DESCRIPTION
This pull request implements an improved version of the sun compensation and also takes into account dark-sky situations. The detailed list of improvements are:

- Lower the probability of whiteout by lowering saturation instead of increasing contrast, when compensating for bright light conditions
- Use Otsu thresholding to automatically separate sky and treeline so that the user does not need to manually specify the threshold value
- Account for dark-sky conditions by increasing the value of dark pixels to improve contrast
- Use pixel-based manipulation of HSV data instead of whole frame manipulation for more adaptive compensation